### PR TITLE
GRAN checks addressed w/ new tags

### DIFF
--- a/gran_source_list.tsv
+++ b/gran_source_list.tsv
@@ -9,3 +9,5 @@ usgs-r/USGSHydroOpt	v1.0.0
 usgs-r/smwrData	v1.0.3
 usgs-r/EflowStats	v4.0.1
 usgs-r/smwrBase	v1.0.3
+GLEON/GLMr	v2.0.10
+usgs-r/glmtools	v0.6.1

--- a/gran_source_list.tsv
+++ b/gran_source_list.tsv
@@ -9,5 +9,5 @@ usgs-r/USGSHydroOpt	v1.0.0
 usgs-r/smwrData	v1.0.3
 usgs-r/EflowStats	v4.0.1
 usgs-r/smwrBase	v1.0.3
-GLEON/GLMr	v2.0.10
-usgs-r/glmtools	v0.6.1
+GLEON/GLMr	v3.0.0
+usgs-r/glmtools	v0.6.2


### PR DESCRIPTION
fixes per @ldecicco-USGS are taken care of. 

Note that GLMr will still build with 1 warning and 2 notes. All three of these issues are associated with the executable models that are wrapped within the package:

- (1) warning for executables
- (2) note for libraries within a source package
- (3) note for large package size