### PR TITLE
add unitted package

### DIFF
--- a/gran_source_list.tsv
+++ b/gran_source_list.tsv
@@ -20,3 +20,4 @@ usgs-r/GSqwsr	1.2.0
 usgs-r/rloadest	v0.4.0
 usgs-r/gsplot	v0.0.1
 usgs-r/gsIntroR	v0.1.1
+appling/unitted	v0.2.4


### PR DESCRIPTION
This addition to GRAN is temporary, in support of `powstreams` (which depends on `unitted`) until I can get `unitted` up on CRAN.

The package builds cleanly on Travis and on my Windows machine with both 3.2.1 and 3.1.3.

`R CMD check --as-cran` runs through `checking for unstated dependencies in 'tests'` with 1 NOTE and 1 WARNING:
```
* checking CRAN incoming feasibility ... NOTE
Maintainer: 'Alison Appling <alison.appling@gmail.com>'
New submission
Non-FOSS package license (file LICENSE)

* checking for unstated dependencies in examples ... OK
 WARNING
'qpdf' is needed for checks on size reduction of PDFs
```
The NOTE about the Non-FOSS license is typical of USGS packages, I believe. Neither the NOTE nor the WARNING appears with simple `R CMD check`.

`R CMD check` fails with an ERROR at `checking tests`. The failing tests document known bugs and will be fixed, either through bug fixes or by removing the tests from the `check` pipeline, in the future.
