### PR TITLE
Update gran_source_list.tsv

### DIFF
--- a/inst/gran_source_list.tsv
+++ b/inst/gran_source_list.tsv
@@ -34,3 +34,4 @@ usgs-r/grithub	0.10.0
 usgs-vizlab/vizlab	v0.1.6
 usgs-r/USGSHydroTools	v1.2.1
 usgs-r/loadflex v1.0.1
+usgs-r/wreg v1.05-02


### PR DESCRIPTION
One warning with differences between DT and Shiny dataTables

e.g.:
  Warning: replacing previous import 'shiny::dataTableOutput' by 'DT::dataTableOutput' when loading 'WREG'
  Warning: replacing previous import 'shiny::renderDataTable' by 'DT::renderDataTable' when loading 'WREG'