### PR TITLE
move mac version switching and rebuilding package to shell script

### DIFF
--- a/R/build_GRAN_all.R
+++ b/R/build_GRAN_all.R
@@ -11,7 +11,7 @@
 #' }
 #' @export
 build_GRAN_all <- function(versions){
-	
+	.Deprecated(new = "shell script inst/mac_build.sh")
 	os = Sys.info()['sysname']
 	if (os == 'Darwin'){
 	  orig.version = dir_version()

--- a/R/dir_version.R
+++ b/R/dir_version.R
@@ -24,15 +24,15 @@ dir_version <- function(){
 #' }
 #' @export
 set_version <- function(version){
-	
+	.Deprecated(new = "shell script inst/mac_build.sh")
 	os = Sys.info()['sysname']
 	if (os == 'Darwin'){
 		current.pointer <- '/Library/Frameworks/R.framework/Versions/Current'
-		set.dir <- sprintf('/Library/Frameworks/R.framework/Versions/%s', version)
-		if (dir.exists(set.dir))
+		set.dir <- version
+		#if (dir.exists(set.dir))
 			system(sprintf('ln -sfhv %s %s', set.dir, current.pointer))
-		else 
-			warning(set.dir, ' does not exist.', call. = FALSE)
+		#else 
+			#warning(set.dir, ' does not exist.', call. = FALSE)
 	} else {
 		message('os ', os, ' is not currently supported')
 	}

--- a/R/dir_version.R
+++ b/R/dir_version.R
@@ -29,10 +29,10 @@ set_version <- function(version){
 	if (os == 'Darwin'){
 		current.pointer <- '/Library/Frameworks/R.framework/Versions/Current'
 		set.dir <- version
-		#if (dir.exists(set.dir))
+		if (dir.exists(set.dir))
 			system(sprintf('ln -sfhv %s %s', set.dir, current.pointer))
-		#else 
-			#warning(set.dir, ' does not exist.', call. = FALSE)
+		else 
+			warning(set.dir, ' does not exist.', call. = FALSE)
 	} else {
 		message('os ', os, ' is not currently supported')
 	}

--- a/inst/mac_build.sh
+++ b/inst/mac_build.sh
@@ -3,8 +3,30 @@
 #do everything build_GRAN_all does for the mac build, then sync w/AWS
 #run this from the main package directory, not from ./inst!
 
-Rscript -e 'library(granbuild); build_GRAN_all(c('3.4', '3.3'))'
+pointer=/Library/Frameworks/R.framework/Versions/Current
+versions=(3.4 3.3)
+origVersion=$(readlink $pointer)
+for ver in ${versions[@]}
+do
+	ln -sfhv $ver $pointer #change version
 
+	#have to be a directory up - is there a better alternative here?
+	cd ~/Documents/R
+	R CMD INSTALL --no-multiarch --with-keep.source grantools	
+	cd ~/Documents/R/grantools
+
+	#only build source for first version
+	if [ $ver == ${versions[0]} ]
+	then
+		Rscript -e 'library(granbuild); dl_build_src(); build_bin()'
+	else
+		Rscript -e 'library(granbuild); build_bin()'
+	fi
+done
+
+ln -sfhv $origVersion $pointer  #reset to original version
+
+#push to S3
 aws s3 sync ~/Documents/R/grantools/GRAN/bin/macosx/mavericks/contrib s3://owi-usgs-gov/R/bin/macosx/mavericks/contrib --delete --profile chsprod
 aws s3 sync ~/Documents/R/grantools/GRAN/bin/macosx/el-capitan/contrib s3://owi-usgs-gov/R/bin/macosx/el-capitan/contrib --delete --profile chsprod
 

--- a/inst/mac_build.sh
+++ b/inst/mac_build.sh
@@ -10,10 +10,7 @@ for ver in ${versions[@]}
 do
 	ln -sfhv $ver $pointer #change version
 
-	#have to be a directory up - is there a better alternative here?
-	cd ~/Documents/R
-	R CMD INSTALL --no-multiarch --with-keep.source grantools	
-	cd ~/Documents/R/grantools
+	R CMD INSTALL --no-multiarch --with-keep.source .	
 
 	#only build source for first version
 	if [ $ver == ${versions[0]} ]


### PR DESCRIPTION
Version switching from within Rstudio was breaking, but it seems to work fine running Rscript directly from the shell.  This also automates rebuilding `granbuild` for each version, so it is really just running this script now.  

We could now eliminate `build_GRAN_all` and `set_version` functions, as  I don't think they are used on windows at all.  